### PR TITLE
Fix(frontend): resolve auth race condition on initial load

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -29,11 +29,15 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const fetchUser = async () => {
-      if (token) {
+    const checkAuth = async () => {
+      const storedToken = localStorage.getItem('token');
+      if (storedToken) {
         try {
+          // Set token for API header
+          api.defaults.headers.common['Authorization'] = `Bearer ${storedToken}`;
           const { data: userData } = await api.get<User>('/users/me');
           setUser(userData);
+          setToken(storedToken);
         } catch (error) {
           console.error('Failed to fetch user', error);
           setToken(null);
@@ -42,8 +46,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       }
       setIsLoading(false);
     };
-    fetchUser();
-  }, [token]);
+
+    checkAuth();
+  }, []);
 
   const login = async (identifiant: string, mot_de_passe: string) => {
     try {


### PR DESCRIPTION
The application was experiencing a race condition in the AuthProvider, causing the dashboard to flash and then disappear for users with an invalid or expired token in localStorage.

This occurred because the `useEffect` responsible for validating the token was dependent on the `token` state itself. This could lead to multiple renders and race conditions where the UI would briefly show a protected route before the token was properly invalidated and the user was redirected.

This commit refactors the `useEffect` in `AuthContext.tsx` to run only once on component mount by using an empty dependency array (`[]`). The logic is now self-contained within the effect, checking for a token in localStorage, validating it, and then setting the application state accordingly. This ensures a stable authentication check on initial load and prevents the UI flash.