### PR TITLE
Refactor: Update codebase to use modern Pydantic and SQLAlchemy APIs

### DIFF
--- a/app/api/v1/schemas/mailing_list.py
+++ b/app/api/v1/schemas/mailing_list.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import Optional, List
 from datetime import datetime
 from .contact import Contact  # Assuming a contact schema exists
@@ -25,9 +25,7 @@ class MailingList(MailingListBase):
     id_campagne: int
     contacts: List[Contact] = []
     created_at: datetime
-
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 class BulkContactOperation(BaseModel):
     contact_ids: List[int]

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,8 +1,9 @@
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import List, Optional
 from pathlib import Path
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
     DATABASE_URL: str
     JWT_SECRET_KEY: str
     JWT_ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
@@ -22,8 +23,5 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379"
     MAX_FILE_SIZE: int = 10485760
     UPLOAD_DIRECTORY: str = "./uploads"
-
-    class Config:
-        env_file = ".env"
 
 settings = Settings()

--- a/tests/api/v1/test_campaigns.py
+++ b/tests/api/v1/test_campaigns.py
@@ -56,7 +56,7 @@ def test_launch_campaign(client: TestClient, db_session: Session, admin_auth_hea
     assert data["queued_count"] == 1
 
     # Verify db changes
-    updated_campaign = db_session.query(Campaign).get(campaign.id_campagne)
+    updated_campaign = db_session.get(Campaign, campaign.id_campagne)
     assert updated_campaign.statut == "active"
     queue_item = db_session.query(SMSQueue).filter_by(campaign_id=campaign.id_campagne).one()
     assert queue_item is not None
@@ -78,7 +78,7 @@ def test_pause_campaign(client: TestClient, db_session: Session, admin_auth_head
 
     # --- Assert ---
     assert response.status_code == 200
-    updated_campaign = db_session.query(Campaign).get(campaign.id_campagne)
+    updated_campaign = db_session.get(Campaign, campaign.id_campagne)
     assert updated_campaign.statut == "paused"
 
 

--- a/tests/api/v1/test_e2e_workflow.py
+++ b/tests/api/v1/test_e2e_workflow.py
@@ -65,7 +65,7 @@ def test_full_campaign_workflow(client: TestClient, db_session: Session, admin_a
     db_session.commit()
 
     # To update the campaign, we must send the full object
-    campaign_obj_before_update = db_session.query(Campaign).get(campaign_id)
+    campaign_obj_before_update = db_session.get(Campaign, campaign_id)
     update_payload = {
         "nom_campagne": campaign_obj_before_update.nom_campagne,
         "date_debut": campaign_obj_before_update.date_debut.isoformat(),
@@ -93,7 +93,7 @@ def test_full_campaign_workflow(client: TestClient, db_session: Session, admin_a
     assert launch_response.json()["success"] is True
 
     # Verify campaign is now active
-    campaign_obj = db_session.query(Campaign).get(campaign_id)
+    campaign_obj = db_session.get(Campaign, campaign_id)
     assert campaign_obj.statut == "active"
 
     # Verify items were added to the SMS queue
@@ -122,5 +122,5 @@ def test_full_campaign_workflow(client: TestClient, db_session: Session, admin_a
     assert pause_response.status_code == 200
 
     # === Step 8: Verify the final state ===
-    final_campaign_obj = db_session.query(Campaign).get(campaign_id)
+    final_campaign_obj = db_session.get(Campaign, campaign_id)
     assert final_campaign_obj.statut == "paused"

--- a/tests/api/v1/test_mailing_lists.py
+++ b/tests/api/v1/test_mailing_lists.py
@@ -253,7 +253,7 @@ class TestContactOperations:
 
         # Verify only opt-in contacts were actually added
         for contact_id in contact_ids_in_list:
-            contact = db_session.query(Contact).get(contact_id)
+            contact = db_session.get(Contact, contact_id)
             assert contact.statut_opt_in is True
 
     def test_remove_contacts_from_list(self, client: TestClient, admin_auth_headers: dict,

--- a/tests/api/v1/test_sms_webhooks.py
+++ b/tests/api/v1/test_sms_webhooks.py
@@ -30,7 +30,7 @@ def test_twilio_webhook_updates_status_delivered(client: TestClient, db_session:
 
     # --- Assert ---
     assert response.status_code == 204
-    updated_message = db_session.query(Message).get(message.id_message)
+    updated_message = db_session.get(Message, message.id_message)
     assert updated_message.statut_livraison == "delivered"
     assert updated_message.cost == Decimal("0.0075")
 
@@ -61,6 +61,6 @@ def test_twilio_webhook_updates_status_failed(client: TestClient, db_session: Se
 
     # --- Assert ---
     assert response.status_code == 204
-    updated_message = db_session.query(Message).get(message.id_message)
+    updated_message = db_session.get(Message, message.id_message)
     assert updated_message.statut_livraison == "failed"
     assert updated_message.error_message == "30005-Message-Delivery-Unknown-error"

--- a/tests/tasks/test_sms_tasks.py
+++ b/tests/tasks/test_sms_tasks.py
@@ -55,7 +55,7 @@ def test_process_sms_queue_success(MockTwilioProvider, MockSessionLocal, db_sess
     process_sms_queue()
 
     # --- Assert ---
-    processed_item = db_session.query(SMSQueue).get(queue_item_id)
+    processed_item = db_session.get(SMSQueue, queue_item_id)
     assert processed_item.status == 'sent'
     assert processed_item.processed_at is not None
 
@@ -90,7 +90,7 @@ def test_process_sms_queue_failure_and_retry(MockTwilioProvider, MockSessionLoca
     process_sms_queue()
 
     # --- Assert ---
-    processed_item = db_session.query(SMSQueue).get(queue_item_id)
+    processed_item = db_session.get(SMSQueue, queue_item_id)
     assert processed_item.status == 'pending'
     assert processed_item.attempts == 1
     assert "Test API Error" in processed_item.error_message


### PR DESCRIPTION
- Replaced legacy Pydantic `Config` class with `model_config` using `ConfigDict` to align with Pydantic v2.
- Updated SQLAlchemy queries from the deprecated `db_session.query(Model).get(id)` to the modern `db_session.get(Model, id)` syntax across the test suite.
- These changes address deprecation warnings and improve the overall quality and maintainability of the codebase.